### PR TITLE
Add fancy template

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,15 @@ This template may be more efficient than the `default` template if you render th
 There is an important caveat: If you `React.renderToString`, the `<symbol>` component will not be included in that HTML string.
 It will only be rendered after the first `<use>` component mounts.
 
+### `fancy` template
+
+This is an opinionated template with a few distinguishing features:
+
+- Applies some accessibility patterns.
+  Adds `aria-hidden` and `focusable="false"` to the `<svg>` element, and exposes an `alt` prop for alternative text (hidden from sight, legible for screen readers).
+- Uses the SVG's `viewbox` attribute to determine an aspect ratio, and applies a wrapper `<div>` and CSS so that the element can have a fluid width while preserving the aspect ratio (across browsers).
+- Adds extra SVGO plugins `removeTitle`, `removeStyleElement`, and `removeAttrs` to remove `width` and `height` from the `<svg>` element.
+
 ## What about other modules that do similar things?
 
 There are many, many npm packages for converting SVGs to React components.

--- a/lib/apply-svgo-plugin-defaults.js
+++ b/lib/apply-svgo-plugin-defaults.js
@@ -2,11 +2,19 @@
 
 const getSvgoPluginName = p => Object.keys(p)[0];
 
-module.exports = (plugins, svgId) => {
+/**
+ * Combines default SVGO plugins with the user's.
+ *
+ * @param {Array<Object>} plugins
+ * @param {string} svgId
+ * @param {Array<Object>} [extraDefaults]
+ * @return {Array<Object>}
+ */
+function applySvgoPluginDefaults(plugins, svgId, extraDefaults) {
   svgId = svgId.replace(/([^a-zA-Z0-9])/g, '');
 
   // All of the defaults
-  const defaultSvgoPlugins = [
+  let defaultSvgoPlugins = [
     { removeDoctype: true },
     { removeComments: true },
     { removeXMLNS: true },
@@ -16,6 +24,9 @@ module.exports = (plugins, svgId) => {
       }
     }
   ];
+  if (extraDefaults) {
+    defaultSvgoPlugins = defaultSvgoPlugins.concat(extraDefaults);
+  }
 
   if (plugins === undefined) {
     return defaultSvgoPlugins;
@@ -26,7 +37,17 @@ module.exports = (plugins, svgId) => {
   defaultSvgoPlugins.forEach(defaultPlugin => {
     if (userPluginNames.has(getSvgoPluginName(defaultPlugin)) === false) {
       defaultedPlugins.push(defaultPlugin);
+    } else if (getSvgoPluginName(defaultPlugin) === 'removeAttrs') {
+      const userAttrs = plugins.find(
+        p => getSvgoPluginName(p) === 'removeAttrs'
+      ).removeAttrs.attrs;
+      const combinedAttrs = defaultPlugin.removeAttrs.attrs.concat(userAttrs);
+      defaultedPlugins.push({
+        removeAttrs: { attrs: combinedAttrs }
+      });
     }
   });
   return defaultedPlugins;
-};
+}
+
+module.exports = applySvgoPluginDefaults;

--- a/lib/reactify-style.js
+++ b/lib/reactify-style.js
@@ -4,8 +4,10 @@ const postcss = require('postcss');
 const postcssJs = require('postcss-js');
 const stringifyObject = require('stringify-object');
 
-module.exports = css => {
+function reactifyStyle(css) {
   const root = postcss.parse(css);
   const obj = postcssJs.objectify(root);
   return stringifyObject(obj);
-};
+}
+
+module.exports = reactifyStyle;

--- a/lib/templates/fancy.js
+++ b/lib/templates/fancy.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const _ = require('lodash');
+const prettier = require('prettier');
+
+function fancy(data) {
+  const viewboxMatch = data.jsxSvg.match(
+    /viewBox="(?:\S+\s+){2}([\d.]+)\s+([\d.]+)"/
+  );
+  const defaultWidth = viewboxMatch[1];
+  const defaultHeight = viewboxMatch[2];
+  const ratio = _.round(defaultHeight / defaultWidth * 100, 2);
+
+  const svg = data.jsxSvg.replace(
+    /^<svg/,
+    `<svg aria-hidden={true}
+      focusable="false"
+      style={svgStyle}
+      className={this.props.svgClassName}`
+  );
+
+  const js = `
+    'use strict';
+    const React = require('react');
+    class ${data.name} extends React.Component {
+      shouldComponentUpdate() { return false; }
+      render() {
+        const containerStyle = this.props.containerStyle || {};
+        if (!containerStyle.position || containerStyle.position === 'static') {
+          containerStyle.position = 'relative';
+        }
+        containerStyle.paddingBottom = '${ratio}%';
+        const svgStyle = this.props.svgStyle || {};
+        svgStyle.position = 'absolute';
+        svgStyle.overflow = 'hidden';
+        svgStyle.top = 0;
+        svgStyle.left = 0;
+        svgStyle.width = '100%';
+        const text = !this.props.alt ? null : (
+          <div style={{ position: 'absolute', left: -9999 }}>
+            {this.props.alt}
+          </div>
+        );
+        return (
+          <div
+            style={containerStyle}
+            className={this.props.containerClassName}
+          >
+            ${svg}
+            {text}
+          </div>
+        )
+      }
+    }
+    module.exports = ${data.name};
+  `;
+
+  return prettier.format(js);
+}
+
+module.exports = fancy;

--- a/lib/templates/index.js
+++ b/lib/templates/index.js
@@ -2,5 +2,6 @@
 
 module.exports = {
   default: require('./default'),
-  useSymbol: require('./use-symbol')
+  useSymbol: require('./use-symbol'),
+  fancy: require('./fancy')
 };

--- a/lib/to-component-module.js
+++ b/lib/to-component-module.js
@@ -5,17 +5,33 @@ const pascalCase = require('pascal-case');
 const toJsx = require('./to-jsx');
 const toInlineSvg = require('./to-inline-svg');
 const templates = require('./templates');
+const applySvgoPluginDefaults = require('./apply-svgo-plugin-defaults');
 
-module.exports = (svg, options) => {
+// See docs in README.
+function toComponentModule(svg, options) {
   options = options || {};
+  options.name =
+    options.name !== undefined ? pascalCase(options.name) : 'SvgComponent';
 
-  const name = options.name !== undefined
-    ? pascalCase(options.name)
-    : 'SvgComponent';
+  if (options.template === 'fancy') {
+    options.svgoPlugins = applySvgoPluginDefaults(
+      options.svgoPlugins,
+      options.name,
+      [
+        { removeStyleElement: true },
+        { removeTitle: true },
+        {
+          removeAttrs: {
+            attrs: ['svg:(width|height)']
+          }
+        }
+      ]
+    );
+  }
 
   const toInlineSvgOptions = {
-    svgoPlugins: options.svgoPlugins,
-    id: options.name
+    id: options.name,
+    svgoPlugins: options.svgoPlugins
   };
 
   return toInlineSvg(svg, toInlineSvgOptions).then(inlineSvg => {
@@ -25,7 +41,7 @@ module.exports = (svg, options) => {
         {
           inlineSvg,
           jsxSvg,
-          name
+          name: options.name
         }
       );
 
@@ -40,4 +56,6 @@ module.exports = (svg, options) => {
       }
     });
   });
-};
+}
+
+module.exports = toComponentModule;

--- a/lib/to-inline-svg.js
+++ b/lib/to-inline-svg.js
@@ -4,7 +4,8 @@ const SVGO = require('svgo');
 const cuid = require('cuid');
 const applySvgoPluginDefaults = require('./apply-svgo-plugin-defaults');
 
-module.exports = (svg, options) => {
+// See docs in README.
+function toInlineSvg(svg, options) {
   options = options || {};
   if (!options.id) options.id = cuid();
   options.svgoPlugins = applySvgoPluginDefaults(
@@ -22,4 +23,6 @@ module.exports = (svg, options) => {
       resolve(result.data);
     });
   });
-};
+}
+
+module.exports = toInlineSvg;

--- a/lib/to-jsx.js
+++ b/lib/to-jsx.js
@@ -20,9 +20,11 @@ const cheerioOptions = {
   xmlMode: true
 };
 
+// See docs in README.
+//
 // _skipOptimization is an internal option used to pass already-optimized
 // SVGs into this.
-module.exports = (svg, options) => {
+function toJsx(svg, options) {
   options = options || {};
   return Promise.resolve()
     .then(() => {
@@ -46,4 +48,6 @@ module.exports = (svg, options) => {
         });
       return jsx;
     });
-};
+}
+
+module.exports = toJsx;

--- a/test/__snapshots__/to-component-module.test.js.snap
+++ b/test/__snapshots__/to-component-module.test.js.snap
@@ -85,6 +85,104 @@ module.exports = SvgComponent;
 "
 `;
 
+exports[`toComponentModule options.template "fancy" 1`] = `
+"\\"use strict\\";
+const React = require(\\"react\\");
+class Fakery extends React.Component {
+  shouldComponentUpdate() {
+    return false;
+  }
+  render() {
+    const containerStyle = this.props.containerStyle || {};
+    if (!containerStyle.position || containerStyle.position === \\"static\\") {
+      containerStyle.position = \\"relative\\";
+    }
+    containerStyle.paddingBottom = \\"100%\\";
+    const svgStyle = this.props.svgStyle || {};
+    svgStyle.position = \\"absolute\\";
+    svgStyle.overflow = \\"hidden\\";
+    svgStyle.top = 0;
+    svgStyle.left = 0;
+    svgStyle.width = \\"100%\\";
+    const text = !this.props.alt
+      ? null
+      : <div style={{ position: \\"absolute\\", left: -9999 }}>
+          {this.props.alt}
+        </div>;
+    return (
+      <div style={containerStyle} className={this.props.containerClassName}>
+        <svg
+          aria-hidden={true}
+          focusable=\\"false\\"
+          style={svgStyle}
+          className={this.props.svgClassName}
+          viewBox=\\"0 0 18 18\\"
+        >
+          <g
+            style={{
+              marginTop: \\"0\\"
+            }}
+          >
+            <path d=\\"M3.4 9.2c.1-1.1.4-2.3 1.5-3.2.9-.7 1.8-.8 2.9-.5 1.4.5 1 .5 2.4 0 1.5-.6 3 0 3.7.8.1.2.2.3 0 .4-1.8 1.3-1.6 3.9.3 5 .2.1.3.2.2.4-.4 1-1 1.9-1.7 2.7-.5.5-1.1.7-1.8.4-.1 0-.3-.1-.4-.1-.9-.1-1.7-.1-2.5.2-.3.1-.5.2-.8.3-.4.1-.8-.1-1.1-.4-.7-.5-1.1-1.2-1.5-1.9-.7-1.1-1.2-2.7-1.2-4.1\\" />
+            <path d=\\"M11.6 2.5c0 1.2-1 2.4-2 2.7-.6.1-.8 0-.7-.6.2-1.2 1.2-2.2 2.5-2.5.2 0 .2 0 .2.2v.2\\" />
+          </g>
+        </svg>
+        {text}
+      </div>
+    );
+  }
+}
+module.exports = Fakery;
+"
+`;
+
+exports[`toComponentModule options.template "fancy" with user-defined removeAttrs plugin 1`] = `
+"\\"use strict\\";
+const React = require(\\"react\\");
+class Fakery extends React.Component {
+  shouldComponentUpdate() {
+    return false;
+  }
+  render() {
+    const containerStyle = this.props.containerStyle || {};
+    if (!containerStyle.position || containerStyle.position === \\"static\\") {
+      containerStyle.position = \\"relative\\";
+    }
+    containerStyle.paddingBottom = \\"100%\\";
+    const svgStyle = this.props.svgStyle || {};
+    svgStyle.position = \\"absolute\\";
+    svgStyle.overflow = \\"hidden\\";
+    svgStyle.top = 0;
+    svgStyle.left = 0;
+    svgStyle.width = \\"100%\\";
+    const text = !this.props.alt
+      ? null
+      : <div style={{ position: \\"absolute\\", left: -9999 }}>
+          {this.props.alt}
+        </div>;
+    return (
+      <div style={containerStyle} className={this.props.containerClassName}>
+        <svg
+          aria-hidden={true}
+          focusable=\\"false\\"
+          style={svgStyle}
+          className={this.props.svgClassName}
+          viewBox=\\"0 0 18 18\\"
+        >
+          <g>
+            <path d=\\"M3.4 9.2c.1-1.1.4-2.3 1.5-3.2.9-.7 1.8-.8 2.9-.5 1.4.5 1 .5 2.4 0 1.5-.6 3 0 3.7.8.1.2.2.3 0 .4-1.8 1.3-1.6 3.9.3 5 .2.1.3.2.2.4-.4 1-1 1.9-1.7 2.7-.5.5-1.1.7-1.8.4-.1 0-.3-.1-.4-.1-.9-.1-1.7-.1-2.5.2-.3.1-.5.2-.8.3-.4.1-.8-.1-1.1-.4-.7-.5-1.1-1.2-1.5-1.9-.7-1.1-1.2-2.7-1.2-4.1\\" />
+            <path d=\\"M11.6 2.5c0 1.2-1 2.4-2 2.7-.6.1-.8 0-.7-.6.2-1.2 1.2-2.2 2.5-2.5.2 0 .2 0 .2.2v.2\\" />
+          </g>
+        </svg>
+        {text}
+      </div>
+    );
+  }
+}
+module.exports = Fakery;
+"
+`;
+
 exports[`toComponentModule options.template "useSymbol" 1`] = `
 "\\"use strict\\";
 const React = require(\\"react\\");
@@ -430,50 +528,7 @@ module.exports = SvgComponent;
 "
 `;
 
-exports[`toComponentModule works with an airplane 1`] = `
-"\\"use strict\\";
-const React = require(\\"react\\");
-
-class SvgComponent extends React.PureComponent {
-  render() {
-    return (
-      <svg {...this.props} viewBox=\\"0 0 18 18\\">
-        <path d=\\"M7 4l1.6 4H5.5S4.1 6 3 6h-.8L3 8l1 3h4.6L7 15h2l3.2-4H14c1 0 2-.7 2-1.5S15 8 14 8h-1.8L9 4H7z\\" />
-      </svg>
-    );
-  }
-}
-
-module.exports = SvgComponent;
-"
-`;
-
-exports[`toComponentModule works with an apple 1`] = `
-"\\"use strict\\";
-const React = require(\\"react\\");
-
-class SvgComponent extends React.PureComponent {
-  render() {
-    return (
-      <svg {...this.props} viewBox=\\"0 0 18 18\\" width=\\"30\\" height=\\"30\\">
-        <g
-          style={{
-            marginTop: \\"0\\"
-          }}
-        >
-          <path d=\\"M3.4 9.2c.1-1.1.4-2.3 1.5-3.2.9-.7 1.8-.8 2.9-.5 1.4.5 1 .5 2.4 0 1.5-.6 3 0 3.7.8.1.2.2.3 0 .4-1.8 1.3-1.6 3.9.3 5 .2.1.3.2.2.4-.4 1-1 1.9-1.7 2.7-.5.5-1.1.7-1.8.4-.1 0-.3-.1-.4-.1-.9-.1-1.7-.1-2.5.2-.3.1-.5.2-.8.3-.4.1-.8-.1-1.1-.4-.7-.5-1.1-1.2-1.5-1.9-.7-1.1-1.2-2.7-1.2-4.1\\" />
-          <path d=\\"M11.6 2.5c0 1.2-1 2.4-2 2.7-.6.1-.8 0-.7-.6.2-1.2 1.2-2.2 2.5-2.5.2 0 .2 0 .2.2v.2\\" />
-        </g>
-      </svg>
-    );
-  }
-}
-
-module.exports = SvgComponent;
-"
-`;
-
-exports[`toComponentModule works with one with style attributes 1`] = `
+exports[`toComponentModule works with a template with style attributes 1`] = `
 "\\"use strict\\";
 const React = require(\\"react\\");
 
@@ -487,7 +542,7 @@ class StyleAttributes extends React.PureComponent {
         viewBox=\\"0 0 79.4 69.855\\"
       >
         <defs>
-          <clipPath id=\\"styleattributes-a\\" transform=\\"translate(-2.3 -8.8)\\">
+          <clipPath id=\\"StyleAttributes-a\\" transform=\\"translate(-2.3 -8.8)\\">
             <rect
               x=\\"2.3\\"
               y=\\"24\\"
@@ -536,7 +591,7 @@ class StyleAttributes extends React.PureComponent {
             isolation: \\"isolate\\"
           }}
         />
-        <g clipPath=\\"url(#styleattributes-a)\\">
+        <g clipPath=\\"url(#StyleAttributes-a)\\">
           <path
             fill=\\"none\\"
             stroke=\\"#774cef\\"
@@ -545,7 +600,7 @@ class StyleAttributes extends React.PureComponent {
             d=\\"M53 10.2l-1.2 1.6\\"
           />
         </g>
-        <g clipPath=\\"url(#styleattributes-a)\\">
+        <g clipPath=\\"url(#StyleAttributes-a)\\">
           <path
             fill=\\"none\\"
             stroke=\\"#774cef\\"
@@ -554,7 +609,7 @@ class StyleAttributes extends React.PureComponent {
             d=\\"M24.3 67.7L23 69.2\\"
           />
         </g>
-        <g clipPath=\\"url(#styleattributes-a)\\">
+        <g clipPath=\\"url(#StyleAttributes-a)\\">
           <path
             fill=\\"none\\"
             stroke=\\"#774cef\\"
@@ -639,5 +694,48 @@ class StyleAttributes extends React.PureComponent {
 }
 
 module.exports = StyleAttributes;
+"
+`;
+
+exports[`toComponentModule works with an airplane 1`] = `
+"\\"use strict\\";
+const React = require(\\"react\\");
+
+class SvgComponent extends React.PureComponent {
+  render() {
+    return (
+      <svg {...this.props} viewBox=\\"0 0 18 18\\">
+        <path d=\\"M7 4l1.6 4H5.5S4.1 6 3 6h-.8L3 8l1 3h4.6L7 15h2l3.2-4H14c1 0 2-.7 2-1.5S15 8 14 8h-1.8L9 4H7z\\" />
+      </svg>
+    );
+  }
+}
+
+module.exports = SvgComponent;
+"
+`;
+
+exports[`toComponentModule works with an apple 1`] = `
+"\\"use strict\\";
+const React = require(\\"react\\");
+
+class SvgComponent extends React.PureComponent {
+  render() {
+    return (
+      <svg {...this.props} viewBox=\\"0 0 18 18\\" width=\\"30\\" height=\\"30\\">
+        <g
+          style={{
+            marginTop: \\"0\\"
+          }}
+        >
+          <path d=\\"M3.4 9.2c.1-1.1.4-2.3 1.5-3.2.9-.7 1.8-.8 2.9-.5 1.4.5 1 .5 2.4 0 1.5-.6 3 0 3.7.8.1.2.2.3 0 .4-1.8 1.3-1.6 3.9.3 5 .2.1.3.2.2.4-.4 1-1 1.9-1.7 2.7-.5.5-1.1.7-1.8.4-.1 0-.3-.1-.4-.1-.9-.1-1.7-.1-2.5.2-.3.1-.5.2-.8.3-.4.1-.8-.1-1.1-.4-.7-.5-1.1-1.2-1.5-1.9-.7-1.1-1.2-2.7-1.2-4.1\\" />
+          <path d=\\"M11.6 2.5c0 1.2-1 2.4-2 2.7-.6.1-.8 0-.7-.6.2-1.2 1.2-2.2 2.5-2.5.2 0 .2 0 .2.2v.2\\" />
+        </g>
+      </svg>
+    );
+  }
+}
+
+module.exports = SvgComponent;
 "
 `;

--- a/test/to-component-module.test.js
+++ b/test/to-component-module.test.js
@@ -69,7 +69,7 @@ describe('toComponentModule', () => {
     });
   });
 
-  test('works with one with style attributes', () => {
+  test('works with a template with style attributes', () => {
     return toComponentModule(getFixture('style-attributes'), {
       name: 'style-attributes'
     }).then(result => {
@@ -173,6 +173,27 @@ describe('toComponentModule', () => {
       name: 'Fakery',
       propTypes: `{ width: PropTypes.number }`,
       template: 'useSymbol'
+    };
+    return toComponentModule(getFixture('apple'), options).then(result => {
+      expect(result).toMatchSnapshot();
+    });
+  });
+
+  test('options.template "fancy"', () => {
+    const options = {
+      name: 'Fakery',
+      template: 'fancy'
+    };
+    return toComponentModule(getFixture('apple'), options).then(result => {
+      expect(result).toMatchSnapshot();
+    });
+  });
+
+  test('options.template "fancy" with user-defined removeAttrs plugin', () => {
+    const options = {
+      name: 'Fakery',
+      template: 'fancy',
+      svgoPlugins: [{ removeAttrs: { attrs: ['style'] } }]
     };
     return toComponentModule(getFixture('apple'), options).then(result => {
       expect(result).toMatchSnapshot();


### PR DESCRIPTION
Adds a `fancy` template. This is an opinionated one that I think we'll use at Mapbox for most SVGs, with accessibility features and fluid-width-maintaining-aspect-ratio.