### PR TITLE
Move props to end of <svg> tag so existing attributes can be overwritten

### DIFF
--- a/lib/templates/default.js
+++ b/lib/templates/default.js
@@ -13,7 +13,10 @@ module.exports = data => {
   if (data.defaultProps !== undefined) {
     defaultProps = `\n${data.name}.defaultProps = ${data.defaultProps}\n`;
   }
-  const jsxSvgWithProps = data.jsxSvg.replace(/^<svg/, '<svg {...this.props}');
+  const jsxSvgWithProps = data.jsxSvg.replace(
+    /<svg([\s\S]*?)>/,
+    (match, group) => `<svg${group} {...this.props}>`
+  );
   const js = `
     'use strict';
     const React = require('react');

--- a/test/__snapshots__/to-component-module.test.js.snap
+++ b/test/__snapshots__/to-component-module.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`toComponentModule Component puts props on <svg> element 1`] = `"<svg viewBox=\\"0 0 18 18\\" width=\\"30\\" height=\\"30\\" data-reactroot=\\"\\" data-reactid=\\"1\\" data-react-checksum=\\"917341117\\"><g style=\\"margin-top:0px;\\" data-reactid=\\"2\\"><path d=\\"M3.4 9.2c.1-1.1.4-2.3 1.5-3.2.9-.7 1.8-.8 2.9-.5 1.4.5 1 .5 2.4 0 1.5-.6 3 0 3.7.8.1.2.2.3 0 .4-1.8 1.3-1.6 3.9.3 5 .2.1.3.2.2.4-.4 1-1 1.9-1.7 2.7-.5.5-1.1.7-1.8.4-.1 0-.3-.1-.4-.1-.9-.1-1.7-.1-2.5.2-.3.1-.5.2-.8.3-.4.1-.8-.1-1.1-.4-.7-.5-1.1-1.2-1.5-1.9-.7-1.1-1.2-2.7-1.2-4.1\\" data-reactid=\\"3\\"></path><path d=\\"M11.6 2.5c0 1.2-1 2.4-2 2.7-.6.1-.8 0-.7-.6.2-1.2 1.2-2.2 2.5-2.5.2 0 .2 0 .2.2v.2\\" data-reactid=\\"4\\"></path></g></svg>"`;
+exports[`toComponentModule Component puts props on <svg> element 1`] = `"<svg viewBox=\\"0 0 18 18\\" width=\\"40\\" height=\\"40\\" data-reactroot=\\"\\" data-reactid=\\"1\\" data-react-checksum=\\"986678207\\"><g style=\\"margin-top:0px;\\" data-reactid=\\"2\\"><path d=\\"M3.4 9.2c.1-1.1.4-2.3 1.5-3.2.9-.7 1.8-.8 2.9-.5 1.4.5 1 .5 2.4 0 1.5-.6 3 0 3.7.8.1.2.2.3 0 .4-1.8 1.3-1.6 3.9.3 5 .2.1.3.2.2.4-.4 1-1 1.9-1.7 2.7-.5.5-1.1.7-1.8.4-.1 0-.3-.1-.4-.1-.9-.1-1.7-.1-2.5.2-.3.1-.5.2-.8.3-.4.1-.8-.1-1.1-.4-.7-.5-1.1-1.2-1.5-1.9-.7-1.1-1.2-2.7-1.2-4.1\\" data-reactid=\\"3\\"></path><path d=\\"M11.6 2.5c0 1.2-1 2.4-2 2.7-.6.1-.8 0-.7-.6.2-1.2 1.2-2.2 2.5-2.5.2 0 .2 0 .2.2v.2\\" data-reactid=\\"4\\"></path></g></svg>"`;
 
 exports[`toComponentModule creates valid React components from a big messy SVG 1`] = `"<svg width=\\"414\\" height=\\"324\\" viewBox=\\"0 0 414 324\\" data-reactroot=\\"\\" data-reactid=\\"1\\" data-react-checksum=\\"82706214\\"><path fill=\\"#FFF\\" d=\\"M.333.333h414v324h-414z\\" data-reactid=\\"2\\"></path><path fill=\\"none\\" d=\\"M152.333 24.298h127.432v109.036H152.333z\\" data-reactid=\\"3\\"></path><switch data-reactid=\\"4\\"><foreignObject requiredExtensions=\\"http://ns.adobe.com/Flows/1.0/\\" x=\\"0\\" y=\\"0\\" width=\\"1\\" height=\\"1\\" overflow=\\"visible\\" data-reactid=\\"5\\"><flowDef xmlns=\\"http://ns.adobe.com/Flows/1.0/\\" data-reactid=\\"6\\"><region data-reactid=\\"7\\"><path fill=\\"none\\" d=\\"M279.765 133.333h-130.49V24.298h130.49v109.035z\\" data-reactid=\\"8\\"></path></region><flow xmlns=\\"http://ns.adobe.com/Flows/1.0/\\" data-reactid=\\"9\\"><p data-reactid=\\"10\\"><span font-family=\\"&#x27;TimesNewRomanPS-BoldMT&#x27;\\" font-size=\\"9\\" data-reactid=\\"11\\">##3$$,</span><span font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"8.894\\" data-reactid=\\"12\\"></span><span font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"7\\" data-reactid=\\"13\\">##2$$</span></p><p data-reactid=\\"14\\"><span font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"8\\" data-reactid=\\"15\\">##1$$,</span><span font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"8.596\\" data-reactid=\\"16\\"></span><span font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"7\\" data-reactid=\\"17\\">##5$$</span></p><p data-reactid=\\"18\\"><span font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"8\\" data-reactid=\\"19\\">##10$$</span></p><p data-reactid=\\"20\\"><span font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"8\\" data-reactid=\\"21\\">##11$$</span></p><p data-reactid=\\"22\\"><span font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"8\\" data-reactid=\\"23\\">##7$$</span></p><p data-reactid=\\"24\\"><span font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"8\\" data-reactid=\\"25\\">##6$$</span></p><p data-reactid=\\"26\\"><span font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"8\\" data-reactid=\\"27\\">##8$$</span></p><p data-reactid=\\"28\\"><span font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"8\\" data-reactid=\\"29\\">##4$$</span></p><p data-reactid=\\"30\\"><span font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"8\\" data-reactid=\\"31\\">##17$$, ##18$$ ##19$$</span></p></flow></flowDef></foreignObject><g data-reactid=\\"32\\"><path fill=\\"none\\" d=\\"M149.275 24.298h130.49v109.036h-130.49z\\" data-reactid=\\"33\\"></path><text transform=\\"translate(235.292 30.48)\\" data-reactid=\\"34\\"><tspan x=\\"0\\" y=\\"0\\" font-family=\\"&#x27;TimesNewRomanPS-BoldMT&#x27;\\" font-size=\\"9\\" data-reactid=\\"35\\">##3$$,</tspan><tspan x=\\"24.75\\" y=\\"0\\" font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"8.894\\" data-reactid=\\"36\\"> </tspan><tspan x=\\"26.974\\" y=\\"0\\" font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"7\\" data-reactid=\\"37\\">##2$$</tspan><tspan x=\\"2.825\\" y=\\"10.314\\" font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"8\\" data-reactid=\\"38\\">##1$$,</tspan><tspan x=\\"24.825\\" y=\\"10.314\\" font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"8.596\\" data-reactid=\\"39\\"> </tspan><tspan x=\\"26.974\\" y=\\"10.314\\" font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"7\\" data-reactid=\\"40\\">##5$$</tspan><tspan x=\\"20.474\\" y=\\"19.915\\" font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"8\\" data-reactid=\\"41\\">##10$$</tspan><tspan x=\\"20.474\\" y=\\"29.515\\" font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"8\\" data-reactid=\\"42\\">##11$$</tspan><tspan x=\\"24.474\\" y=\\"39.115\\" font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"8\\" data-reactid=\\"43\\">##7$$</tspan><tspan x=\\"24.474\\" y=\\"48.715\\" font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"8\\" data-reactid=\\"44\\">##6$$</tspan><tspan x=\\"24.474\\" y=\\"58.314\\" font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"8\\" data-reactid=\\"45\\">##8$$</tspan><tspan x=\\"24.474\\" y=\\"67.915\\" font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"8\\" data-reactid=\\"46\\">##4$$</tspan><tspan x=\\"-33.526\\" y=\\"77.515\\" font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"8\\" data-reactid=\\"47\\">##17$$, ##18$$ ##19$$</tspan></text></g></switch><path fill=\\"#251413\\" d=\\"M288.016 17.766h109.256v87.97H288.016z\\" data-reactid=\\"48\\"></path><path fill=\\"#4C2525\\" d=\\"M46.389 234.756h13.958v13.958H46.389zM46.389 218.081h13.958v13.958H46.389z\\" data-reactid=\\"49\\"></path><g data-reactid=\\"50\\"><path fill=\\"none\\" d=\\"M66.715 220.205h115.852v30.135H66.715z\\" data-reactid=\\"51\\"></path><switch data-reactid=\\"52\\"><foreignObject requiredExtensions=\\"http://ns.adobe.com/Flows/1.0/\\" x=\\"0\\" y=\\"0\\" width=\\"1\\" height=\\"1\\" overflow=\\"visible\\" data-reactid=\\"53\\"><flowDef xmlns=\\"http://ns.adobe.com/Flows/1.0/\\" data-reactid=\\"54\\"><region data-reactid=\\"55\\"><path fill=\\"none\\" d=\\"M190.394 245.59H66.715v-25.385h123.679v25.385z\\" data-reactid=\\"56\\"></path></region><flow xmlns=\\"http://ns.adobe.com/Flows/1.0/\\" font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"5\\" data-reactid=\\"57\\"><p data-reactid=\\"58\\"><span data-reactid=\\"59\\">##25$$</span></p></flow></flowDef></foreignObject><g data-reactid=\\"60\\"><path fill=\\"none\\" d=\\"M66.715 220.205h123.679v25.385H66.715z\\" data-reactid=\\"61\\"></path><text transform=\\"translate(66.715 223.68)\\" font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"5\\" data-reactid=\\"62\\">##25$$</text></g></switch></g></svg>"`;
 
@@ -13,7 +13,7 @@ const React = require(\\"react\\");
 class SvgComponent extends React.PureComponent {
   render() {
     return (
-      <svg {...this.props} viewBox=\\"0 0 18 18\\">
+      <svg viewBox=\\"0 0 18 18\\" {...this.props}>
         <path d=\\"M7 4l1.6 4H5.5S4.1 6 3 6h-.8L3 8l1 3h4.6L7 15h2l3.2-4H14c1 0 2-.7 2-1.5S15 8 14 8h-1.8L9 4H7z\\" />
       </svg>
     );
@@ -36,7 +36,7 @@ const React = require(\\"react\\");
 class Apple extends React.PureComponent {
   render() {
     return (
-      <svg {...this.props} viewBox=\\"0 0 18 18\\" width=\\"30\\" height=\\"30\\">
+      <svg viewBox=\\"0 0 18 18\\" width=\\"30\\" height=\\"30\\" {...this.props}>
         <g
           style={{
             marginTop: \\"0\\"
@@ -83,7 +83,7 @@ var SvgComponent = function (_React$PureComponent) {
     value: function render() {
       return React.createElement(
         \\"svg\\",
-        _extends({}, this.props, { viewBox: \\"0 0 18 18\\" }),
+        _extends({ viewBox: \\"0 0 18 18\\" }, this.props),
         React.createElement(\\"path\\", { d: \\"M7 4l1.6 4H5.5S4.1 6 3 6h-.8L3 8l1 3h4.6L7 15h2l3.2-4H14c1 0 2-.7 2-1.5S15 8 14 8h-1.8L9 4H7z\\" })
       );
     }
@@ -105,7 +105,7 @@ const PropTypes = require(\\"prop-types\\");
 class SvgComponent extends React.PureComponent {
   render() {
     return (
-      <svg {...this.props} viewBox=\\"0 0 18 18\\" width=\\"30\\" height=\\"30\\">
+      <svg viewBox=\\"0 0 18 18\\" width=\\"30\\" height=\\"30\\" {...this.props}>
         <g
           style={{
             marginTop: \\"0\\"
@@ -147,11 +147,9 @@ class Fakery extends React.Component {
     svgStyle.top = 0;
     svgStyle.left = 0;
     svgStyle.width = \\"100%\\";
-    const text = !this.props.alt
-      ? null
-      : <div style={{ position: \\"absolute\\", left: -9999 }}>
-          {this.props.alt}
-        </div>;
+    const text = !this.props.alt ? null : (
+      <div style={{ position: \\"absolute\\", left: -9999 }}>{this.props.alt}</div>
+    );
     return (
       <div style={containerStyle} className={this.props.containerClassName}>
         <svg
@@ -198,11 +196,9 @@ class Fakery extends React.Component {
     svgStyle.top = 0;
     svgStyle.left = 0;
     svgStyle.width = \\"100%\\";
-    const text = !this.props.alt
-      ? null
-      : <div style={{ position: \\"absolute\\", left: -9999 }}>
-          {this.props.alt}
-        </div>;
+    const text = !this.props.alt ? null : (
+      <div style={{ position: \\"absolute\\", left: -9999 }}>{this.props.alt}</div>
+    );
     return (
       <div style={containerStyle} className={this.props.containerClassName}>
         <svg
@@ -241,7 +237,7 @@ const React = require(\\"react\\");
 class SvgComponent extends React.PureComponent {
   render() {
     return (
-      <svg {...this.props} viewBox=\\"0 0 18 18\\">
+      <svg viewBox=\\"0 0 18 18\\" {...this.props}>
         <g
           style={{
             marginTop: \\"0\\"
@@ -266,7 +262,7 @@ const React = require(\\"react\\");
 class SvgComponent extends React.PureComponent {
   render() {
     return (
-      <svg {...this.props} width=\\"414\\" height=\\"324\\" viewBox=\\"0 0 414 324\\">
+      <svg width=\\"414\\" height=\\"324\\" viewBox=\\"0 0 414 324\\" {...this.props}>
         <path fill=\\"#FFF\\" d=\\"M.333.333h414v324h-414z\\" />
         <path fill=\\"none\\" d=\\"M152.333 24.298h127.432v109.036H152.333z\\" />
         <switch>
@@ -515,10 +511,10 @@ class StyleAttributes extends React.PureComponent {
   render() {
     return (
       <svg
-        {...this.props}
         width=\\"79.4\\"
         height=\\"69.855\\"
         viewBox=\\"0 0 79.4 69.855\\"
+        {...this.props}
       >
         <defs>
           <clipPath id=\\"StyleAttributes-a\\" transform=\\"translate(-2.3 -8.8)\\">
@@ -683,7 +679,7 @@ const React = require(\\"react\\");
 class SvgComponent extends React.PureComponent {
   render() {
     return (
-      <svg {...this.props} viewBox=\\"0 0 18 18\\">
+      <svg viewBox=\\"0 0 18 18\\" {...this.props}>
         <path d=\\"M7 4l1.6 4H5.5S4.1 6 3 6h-.8L3 8l1 3h4.6L7 15h2l3.2-4H14c1 0 2-.7 2-1.5S15 8 14 8h-1.8L9 4H7z\\" />
       </svg>
     );
@@ -701,7 +697,7 @@ const React = require(\\"react\\");
 class SvgComponent extends React.PureComponent {
   render() {
     return (
-      <svg {...this.props} viewBox=\\"0 0 18 18\\" width=\\"30\\" height=\\"30\\">
+      <svg viewBox=\\"0 0 18 18\\" width=\\"30\\" height=\\"30\\" {...this.props}>
         <g
           style={{
             marginTop: \\"0\\"

--- a/test/to-component-module.test.js
+++ b/test/to-component-module.test.js
@@ -33,9 +33,7 @@ const loadOutputModule = content => {
 };
 
 const renderComponent = (Component, props) => {
-  return ReactDOMServer.renderToString(
-    React.createElement(Component, null, props)
-  );
+  return ReactDOMServer.renderToString(React.createElement(Component, props));
 };
 
 describe('toComponentModule', () => {
@@ -106,7 +104,7 @@ describe('toComponentModule', () => {
       })
       .then(Output => {
         const renderedWithProps = renderComponent(Output, {
-          width: 30,
+          width: 40,
           height: 40
         });
         expect(renderedWithProps).toMatchSnapshot();


### PR DESCRIPTION
When using the default template, it’s nice to be able overwrite attributes already present on the <svg> tag. Example:

```js
// Old: overwriting existing attributes cannot be done by passing in props
<svg {...this.props} viewBox="0 0 32 32" width="32" height="32">

// New: existing attributes can be overwritten when desired
<svg viewBox="0 0 32 32" width="32" height="32" {...this.props}>
```

This PR also fixes the `renderComponent` used in the `toComponentModule` tests. This function used `props` as the third argument to `React.createElement`, but it’s actually the second. Corresponding snapshots have also been updated.