### PR TITLE
Replace all style strings with jsx style objects

### DIFF
--- a/packages/svg-react-transformer/lib/to-jsx.js
+++ b/packages/svg-react-transformer/lib/to-jsx.js
@@ -42,7 +42,7 @@ function toJsx(svg, options) {
         .replace(/&apos;/g, "'")
         .replace(/&quot;/g, '"')
         // Replace style attribute values with stringified style objects.
-        .replace(/style="([\s\S]*?[^\\])"/, (match, p1) => {
+        .replace(/style="([\s\S]*?[^\\])"/g, (match, p1) => {
           return `style={${cssToStyleObjectString(p1)}}`;
         });
       return jsx;

--- a/packages/svg-react-transformer/test/__snapshots__/to-component-module.test.js.snap
+++ b/packages/svg-react-transformer/test/__snapshots__/to-component-module.test.js.snap
@@ -625,7 +625,9 @@ class StyleAttributes extends React.PureComponent {
           r=\\"5.8\\"
           fill=\\"#c5b8ed\\"
           opacity=\\".5\\"
-          style=\\"isolation:isolate\\"
+          style={{
+            isolation: \\"isolate\\"
+          }}
         />
         <circle
           cx=\\"31.9\\"
@@ -633,7 +635,9 @@ class StyleAttributes extends React.PureComponent {
           r=\\"1.4\\"
           fill=\\"#c5b8ed\\"
           opacity=\\".5\\"
-          style=\\"isolation:isolate\\"
+          style={{
+            isolation: \\"isolate\\"
+          }}
         />
         <circle
           cx=\\"47.8\\"
@@ -641,7 +645,9 @@ class StyleAttributes extends React.PureComponent {
           r=\\"1.4\\"
           fill=\\"#c5b8ed\\"
           opacity=\\".5\\"
-          style=\\"isolation:isolate\\"
+          style={{
+            isolation: \\"isolate\\"
+          }}
         />
         <circle
           cx=\\"31\\"
@@ -649,7 +655,9 @@ class StyleAttributes extends React.PureComponent {
           r=\\"1.4\\"
           fill=\\"#c5b8ed\\"
           opacity=\\".5\\"
-          style=\\"isolation:isolate\\"
+          style={{
+            isolation: \\"isolate\\"
+          }}
         />
         <circle
           cx=\\"21.6\\"
@@ -657,7 +665,9 @@ class StyleAttributes extends React.PureComponent {
           r=\\"3.2\\"
           fill=\\"#dad2f9\\"
           opacity=\\".5\\"
-          style=\\"isolation:isolate\\"
+          style={{
+            isolation: \\"isolate\\"
+          }}
         />
         <circle
           cx=\\"40.5\\"
@@ -665,7 +675,9 @@ class StyleAttributes extends React.PureComponent {
           r=\\"3.5\\"
           fill=\\"#c5b8ed\\"
           opacity=\\".5\\"
-          style=\\"isolation:isolate\\"
+          style={{
+            isolation: \\"isolate\\"
+          }}
         />
         <circle
           cx=\\"40.5\\"
@@ -673,7 +685,9 @@ class StyleAttributes extends React.PureComponent {
           r=\\"1.7\\"
           fill=\\"#dad2f9\\"
           opacity=\\".5\\"
-          style=\\"isolation:isolate\\"
+          style={{
+            isolation: \\"isolate\\"
+          }}
         />
         <path
           fill=\\"#dad2f9\\"

--- a/packages/svg-react-transformer/test/__snapshots__/to-jsx.test.js.snap
+++ b/packages/svg-react-transformer/test/__snapshots__/to-jsx.test.js.snap
@@ -475,7 +475,9 @@ exports[`toJsx works on one with style attributes 1`] = `
     r=\\"5.8\\"
     fill=\\"#c5b8ed\\"
     opacity=\\".5\\"
-    style=\\"isolation:isolate\\"
+    style={{
+      isolation: \\"isolate\\"
+    }}
   />
   <circle
     cx=\\"31.9\\"
@@ -483,7 +485,9 @@ exports[`toJsx works on one with style attributes 1`] = `
     r=\\"1.4\\"
     fill=\\"#c5b8ed\\"
     opacity=\\".5\\"
-    style=\\"isolation:isolate\\"
+    style={{
+      isolation: \\"isolate\\"
+    }}
   />
   <circle
     cx=\\"47.8\\"
@@ -491,7 +495,9 @@ exports[`toJsx works on one with style attributes 1`] = `
     r=\\"1.4\\"
     fill=\\"#c5b8ed\\"
     opacity=\\".5\\"
-    style=\\"isolation:isolate\\"
+    style={{
+      isolation: \\"isolate\\"
+    }}
   />
   <circle
     cx=\\"31\\"
@@ -499,7 +505,9 @@ exports[`toJsx works on one with style attributes 1`] = `
     r=\\"1.4\\"
     fill=\\"#c5b8ed\\"
     opacity=\\".5\\"
-    style=\\"isolation:isolate\\"
+    style={{
+      isolation: \\"isolate\\"
+    }}
   />
   <circle
     cx=\\"21.6\\"
@@ -507,7 +515,9 @@ exports[`toJsx works on one with style attributes 1`] = `
     r=\\"3.2\\"
     fill=\\"#dad2f9\\"
     opacity=\\".5\\"
-    style=\\"isolation:isolate\\"
+    style={{
+      isolation: \\"isolate\\"
+    }}
   />
   <circle
     cx=\\"40.5\\"
@@ -515,7 +525,9 @@ exports[`toJsx works on one with style attributes 1`] = `
     r=\\"3.5\\"
     fill=\\"#c5b8ed\\"
     opacity=\\".5\\"
-    style=\\"isolation:isolate\\"
+    style={{
+      isolation: \\"isolate\\"
+    }}
   />
   <circle
     cx=\\"40.5\\"
@@ -523,7 +535,9 @@ exports[`toJsx works on one with style attributes 1`] = `
     r=\\"1.7\\"
     fill=\\"#dad2f9\\"
     opacity=\\".5\\"
-    style=\\"isolation:isolate\\"
+    style={{
+      isolation: \\"isolate\\"
+    }}
   />
   <path
     fill=\\"#dad2f9\\"


### PR DESCRIPTION
Fixes #12

This PR adds the `g` regex modifier to the `.replace` call that transforms inline `style` attribute strings to JSX-style `style` objects.
