### PR TITLE
Fix missing viewBox

### DIFF
--- a/packages/svg-react-transformer/lib/apply-svgo-plugin-defaults.js
+++ b/packages/svg-react-transformer/lib/apply-svgo-plugin-defaults.js
@@ -17,6 +17,7 @@ function applySvgoPluginDefaults(plugins, svgId, extraDefaults) {
   let defaultSvgoPlugins = [
     { removeDoctype: true },
     { removeComments: true },
+    { removeViewBox: false },
     { removeXMLNS: true },
     {
       cleanupIDs: {

--- a/packages/svg-react-transformer/test/__snapshots__/to-component-module.test.js.snap
+++ b/packages/svg-react-transformer/test/__snapshots__/to-component-module.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`toComponentModule Component puts props on <svg> element 1`] = `"<svg viewBox=\\"0 0 18 18\\" width=\\"40\\" height=\\"40\\" data-reactroot=\\"\\" data-reactid=\\"1\\" data-react-checksum=\\"986678207\\"><g style=\\"margin-top:0px;\\" data-reactid=\\"2\\"><path d=\\"M3.4 9.2c.1-1.1.4-2.3 1.5-3.2.9-.7 1.8-.8 2.9-.5 1.4.5 1 .5 2.4 0 1.5-.6 3 0 3.7.8.1.2.2.3 0 .4-1.8 1.3-1.6 3.9.3 5 .2.1.3.2.2.4-.4 1-1 1.9-1.7 2.7-.5.5-1.1.7-1.8.4-.1 0-.3-.1-.4-.1-.9-.1-1.7-.1-2.5.2-.3.1-.5.2-.8.3-.4.1-.8-.1-1.1-.4-.7-.5-1.1-1.2-1.5-1.9-.7-1.1-1.2-2.7-1.2-4.1\\" data-reactid=\\"3\\"></path><path d=\\"M11.6 2.5c0 1.2-1 2.4-2 2.7-.6.1-.8 0-.7-.6.2-1.2 1.2-2.2 2.5-2.5.2 0 .2 0 .2.2v.2\\" data-reactid=\\"4\\"></path></g></svg>"`;
 
-exports[`toComponentModule creates valid React components from a big messy SVG 1`] = `"<svg width=\\"414\\" height=\\"324\\" data-reactroot=\\"\\" data-reactid=\\"1\\" data-react-checksum=\\"1371404719\\"><path fill=\\"#FFF\\" d=\\"M.333.333h414v324h-414z\\" data-reactid=\\"2\\"></path><path fill=\\"none\\" d=\\"M152.333 24.298h127.432v109.036H152.333z\\" data-reactid=\\"3\\"></path><switch data-reactid=\\"4\\"><foreignObject requiredExtensions=\\"http://ns.adobe.com/Flows/1.0/\\" x=\\"0\\" y=\\"0\\" width=\\"1\\" height=\\"1\\" overflow=\\"visible\\" data-reactid=\\"5\\"><flowDef xmlns=\\"http://ns.adobe.com/Flows/1.0/\\" data-reactid=\\"6\\"><region data-reactid=\\"7\\"><path fill=\\"none\\" d=\\"M279.765 133.333h-130.49V24.298h130.49v109.035z\\" data-reactid=\\"8\\"></path></region><flow xmlns=\\"http://ns.adobe.com/Flows/1.0/\\" data-reactid=\\"9\\"><p data-reactid=\\"10\\"><span font-family=\\"&#x27;TimesNewRomanPS-BoldMT&#x27;\\" font-size=\\"9\\" data-reactid=\\"11\\">##3$$,</span><span font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"8.894\\" data-reactid=\\"12\\"></span><span font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"7\\" data-reactid=\\"13\\">##2$$</span></p><p data-reactid=\\"14\\"><span font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"8\\" data-reactid=\\"15\\">##1$$,</span><span font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"8.596\\" data-reactid=\\"16\\"></span><span font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"7\\" data-reactid=\\"17\\">##5$$</span></p><p data-reactid=\\"18\\"><span font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"8\\" data-reactid=\\"19\\">##10$$</span></p><p data-reactid=\\"20\\"><span font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"8\\" data-reactid=\\"21\\">##11$$</span></p><p data-reactid=\\"22\\"><span font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"8\\" data-reactid=\\"23\\">##7$$</span></p><p data-reactid=\\"24\\"><span font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"8\\" data-reactid=\\"25\\">##6$$</span></p><p data-reactid=\\"26\\"><span font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"8\\" data-reactid=\\"27\\">##8$$</span></p><p data-reactid=\\"28\\"><span font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"8\\" data-reactid=\\"29\\">##4$$</span></p><p data-reactid=\\"30\\"><span font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"8\\" data-reactid=\\"31\\">##17$$, ##18$$ ##19$$</span></p></flow></flowDef></foreignObject><g data-reactid=\\"32\\"><path fill=\\"none\\" d=\\"M149.275 24.298h130.49v109.036h-130.49z\\" data-reactid=\\"33\\"></path><text transform=\\"translate(235.292 30.48)\\" data-reactid=\\"34\\"><tspan x=\\"0\\" y=\\"0\\" font-family=\\"&#x27;TimesNewRomanPS-BoldMT&#x27;\\" font-size=\\"9\\" data-reactid=\\"35\\">##3$$,</tspan><tspan x=\\"24.75\\" y=\\"0\\" font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"8.894\\" data-reactid=\\"36\\"> </tspan><tspan x=\\"26.974\\" y=\\"0\\" font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"7\\" data-reactid=\\"37\\">##2$$</tspan><tspan x=\\"2.825\\" y=\\"10.314\\" font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"8\\" data-reactid=\\"38\\">##1$$,</tspan><tspan x=\\"24.825\\" y=\\"10.314\\" font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"8.596\\" data-reactid=\\"39\\"> </tspan><tspan x=\\"26.974\\" y=\\"10.314\\" font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"7\\" data-reactid=\\"40\\">##5$$</tspan><tspan x=\\"20.474\\" y=\\"19.915\\" font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"8\\" data-reactid=\\"41\\">##10$$</tspan><tspan x=\\"20.474\\" y=\\"29.515\\" font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"8\\" data-reactid=\\"42\\">##11$$</tspan><tspan x=\\"24.474\\" y=\\"39.115\\" font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"8\\" data-reactid=\\"43\\">##7$$</tspan><tspan x=\\"24.474\\" y=\\"48.715\\" font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"8\\" data-reactid=\\"44\\">##6$$</tspan><tspan x=\\"24.474\\" y=\\"58.314\\" font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"8\\" data-reactid=\\"45\\">##8$$</tspan><tspan x=\\"24.474\\" y=\\"67.915\\" font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"8\\" data-reactid=\\"46\\">##4$$</tspan><tspan x=\\"-33.526\\" y=\\"77.515\\" font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"8\\" data-reactid=\\"47\\">##17$$, ##18$$ ##19$$</tspan></text></g></switch><path fill=\\"#251413\\" d=\\"M288.016 17.766h109.256v87.97H288.016z\\" data-reactid=\\"48\\"></path><path fill=\\"#4C2525\\" d=\\"M46.389 234.756h13.958v13.958H46.389zM46.389 218.081h13.958v13.958H46.389z\\" data-reactid=\\"49\\"></path><g data-reactid=\\"50\\"><path fill=\\"none\\" d=\\"M66.715 220.205h115.852v30.135H66.715z\\" data-reactid=\\"51\\"></path><switch data-reactid=\\"52\\"><foreignObject requiredExtensions=\\"http://ns.adobe.com/Flows/1.0/\\" x=\\"0\\" y=\\"0\\" width=\\"1\\" height=\\"1\\" overflow=\\"visible\\" data-reactid=\\"53\\"><flowDef xmlns=\\"http://ns.adobe.com/Flows/1.0/\\" data-reactid=\\"54\\"><region data-reactid=\\"55\\"><path fill=\\"none\\" d=\\"M190.394 245.59H66.715v-25.385h123.679v25.385z\\" data-reactid=\\"56\\"></path></region><flow xmlns=\\"http://ns.adobe.com/Flows/1.0/\\" font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"5\\" data-reactid=\\"57\\"><p data-reactid=\\"58\\"><span data-reactid=\\"59\\">##25$$</span></p></flow></flowDef></foreignObject><g data-reactid=\\"60\\"><path fill=\\"none\\" d=\\"M66.715 220.205h123.679v25.385H66.715z\\" data-reactid=\\"61\\"></path><text transform=\\"translate(66.715 223.68)\\" font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"5\\" data-reactid=\\"62\\">##25$$</text></g></switch></g></svg>"`;
+exports[`toComponentModule creates valid React components from a big messy SVG 1`] = `"<svg width=\\"414\\" height=\\"324\\" viewBox=\\"0 0 414 324\\" data-reactroot=\\"\\" data-reactid=\\"1\\" data-react-checksum=\\"82706214\\"><path fill=\\"#FFF\\" d=\\"M.333.333h414v324h-414z\\" data-reactid=\\"2\\"></path><path fill=\\"none\\" d=\\"M152.333 24.298h127.432v109.036H152.333z\\" data-reactid=\\"3\\"></path><switch data-reactid=\\"4\\"><foreignObject requiredExtensions=\\"http://ns.adobe.com/Flows/1.0/\\" x=\\"0\\" y=\\"0\\" width=\\"1\\" height=\\"1\\" overflow=\\"visible\\" data-reactid=\\"5\\"><flowDef xmlns=\\"http://ns.adobe.com/Flows/1.0/\\" data-reactid=\\"6\\"><region data-reactid=\\"7\\"><path fill=\\"none\\" d=\\"M279.765 133.333h-130.49V24.298h130.49v109.035z\\" data-reactid=\\"8\\"></path></region><flow xmlns=\\"http://ns.adobe.com/Flows/1.0/\\" data-reactid=\\"9\\"><p data-reactid=\\"10\\"><span font-family=\\"&#x27;TimesNewRomanPS-BoldMT&#x27;\\" font-size=\\"9\\" data-reactid=\\"11\\">##3$$,</span><span font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"8.894\\" data-reactid=\\"12\\"></span><span font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"7\\" data-reactid=\\"13\\">##2$$</span></p><p data-reactid=\\"14\\"><span font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"8\\" data-reactid=\\"15\\">##1$$,</span><span font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"8.596\\" data-reactid=\\"16\\"></span><span font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"7\\" data-reactid=\\"17\\">##5$$</span></p><p data-reactid=\\"18\\"><span font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"8\\" data-reactid=\\"19\\">##10$$</span></p><p data-reactid=\\"20\\"><span font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"8\\" data-reactid=\\"21\\">##11$$</span></p><p data-reactid=\\"22\\"><span font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"8\\" data-reactid=\\"23\\">##7$$</span></p><p data-reactid=\\"24\\"><span font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"8\\" data-reactid=\\"25\\">##6$$</span></p><p data-reactid=\\"26\\"><span font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"8\\" data-reactid=\\"27\\">##8$$</span></p><p data-reactid=\\"28\\"><span font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"8\\" data-reactid=\\"29\\">##4$$</span></p><p data-reactid=\\"30\\"><span font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"8\\" data-reactid=\\"31\\">##17$$, ##18$$ ##19$$</span></p></flow></flowDef></foreignObject><g data-reactid=\\"32\\"><path fill=\\"none\\" d=\\"M149.275 24.298h130.49v109.036h-130.49z\\" data-reactid=\\"33\\"></path><text transform=\\"translate(235.292 30.48)\\" data-reactid=\\"34\\"><tspan x=\\"0\\" y=\\"0\\" font-family=\\"&#x27;TimesNewRomanPS-BoldMT&#x27;\\" font-size=\\"9\\" data-reactid=\\"35\\">##3$$,</tspan><tspan x=\\"24.75\\" y=\\"0\\" font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"8.894\\" data-reactid=\\"36\\"> </tspan><tspan x=\\"26.974\\" y=\\"0\\" font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"7\\" data-reactid=\\"37\\">##2$$</tspan><tspan x=\\"2.825\\" y=\\"10.314\\" font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"8\\" data-reactid=\\"38\\">##1$$,</tspan><tspan x=\\"24.825\\" y=\\"10.314\\" font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"8.596\\" data-reactid=\\"39\\"> </tspan><tspan x=\\"26.974\\" y=\\"10.314\\" font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"7\\" data-reactid=\\"40\\">##5$$</tspan><tspan x=\\"20.474\\" y=\\"19.915\\" font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"8\\" data-reactid=\\"41\\">##10$$</tspan><tspan x=\\"20.474\\" y=\\"29.515\\" font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"8\\" data-reactid=\\"42\\">##11$$</tspan><tspan x=\\"24.474\\" y=\\"39.115\\" font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"8\\" data-reactid=\\"43\\">##7$$</tspan><tspan x=\\"24.474\\" y=\\"48.715\\" font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"8\\" data-reactid=\\"44\\">##6$$</tspan><tspan x=\\"24.474\\" y=\\"58.314\\" font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"8\\" data-reactid=\\"45\\">##8$$</tspan><tspan x=\\"24.474\\" y=\\"67.915\\" font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"8\\" data-reactid=\\"46\\">##4$$</tspan><tspan x=\\"-33.526\\" y=\\"77.515\\" font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"8\\" data-reactid=\\"47\\">##17$$, ##18$$ ##19$$</tspan></text></g></switch><path fill=\\"#251413\\" d=\\"M288.016 17.766h109.256v87.97H288.016z\\" data-reactid=\\"48\\"></path><path fill=\\"#4C2525\\" d=\\"M46.389 234.756h13.958v13.958H46.389zM46.389 218.081h13.958v13.958H46.389z\\" data-reactid=\\"49\\"></path><g data-reactid=\\"50\\"><path fill=\\"none\\" d=\\"M66.715 220.205h115.852v30.135H66.715z\\" data-reactid=\\"51\\"></path><switch data-reactid=\\"52\\"><foreignObject requiredExtensions=\\"http://ns.adobe.com/Flows/1.0/\\" x=\\"0\\" y=\\"0\\" width=\\"1\\" height=\\"1\\" overflow=\\"visible\\" data-reactid=\\"53\\"><flowDef xmlns=\\"http://ns.adobe.com/Flows/1.0/\\" data-reactid=\\"54\\"><region data-reactid=\\"55\\"><path fill=\\"none\\" d=\\"M190.394 245.59H66.715v-25.385h123.679v25.385z\\" data-reactid=\\"56\\"></path></region><flow xmlns=\\"http://ns.adobe.com/Flows/1.0/\\" font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"5\\" data-reactid=\\"57\\"><p data-reactid=\\"58\\"><span data-reactid=\\"59\\">##25$$</span></p></flow></flowDef></foreignObject><g data-reactid=\\"60\\"><path fill=\\"none\\" d=\\"M66.715 220.205h123.679v25.385H66.715z\\" data-reactid=\\"61\\"></path><text transform=\\"translate(66.715 223.68)\\" font-family=\\"&#x27;TimesNewRomanPSMT&#x27;\\" font-size=\\"5\\" data-reactid=\\"62\\">##25$$</text></g></switch></g></svg>"`;
 
 exports[`toComponentModule creates valid React components from an airplane 1`] = `"<svg viewBox=\\"0 0 18 18\\" data-reactroot=\\"\\" data-reactid=\\"1\\" data-react-checksum=\\"994718638\\"><path d=\\"M7 4l1.6 4H5.5S4.1 6 3 6h-.8L3 8l1 3h4.6L7 15h2l3.2-4H14c1 0 2-.7 2-1.5S15 8 14 8h-1.8L9 4H7z\\" data-reactid=\\"2\\"></path></svg>"`;
 
@@ -258,6 +258,288 @@ module.exports = Fakery;
 "
 `;
 
+exports[`toComponentModule options.template "fancy" with svg that could trigger removeViewBox 1`] = `
+"\\"use strict\\";
+const React = require(\\"react\\");
+class Fakery extends React.PureComponent {
+  render() {
+    const containerStyle = {};
+    Object.keys(this.props.containerStyle).forEach(key => {
+      containerStyle[key] = this.props.containerStyle[key];
+    });
+    if (!containerStyle.position || containerStyle.position === \\"static\\") {
+      containerStyle.position = \\"relative\\";
+    }
+    containerStyle.paddingBottom = \\"78.26%\\";
+
+    const svgStyle = {};
+    Object.keys(this.props.svgStyle).forEach(key => {
+      svgStyle[key] = this.props.svgStyle[key];
+    });
+    svgStyle.position = \\"absolute\\";
+    svgStyle.overflow = \\"hidden\\";
+    svgStyle.top = 0;
+    svgStyle.left = 0;
+    svgStyle.width = \\"100%\\";
+
+    const text = !this.props.alt ? null : (
+      <div style={{ position: \\"absolute\\", left: -9999 }}>{this.props.alt}</div>
+    );
+
+    return (
+      <div style={containerStyle} className={this.props.containerClassName}>
+        <svg
+          aria-hidden={true}
+          focusable=\\"false\\"
+          style={svgStyle}
+          className={this.props.svgClassName}
+          viewBox=\\"0 0 414 324\\"
+        >
+          <path fill=\\"#FFF\\" d=\\"M.333.333h414v324h-414z\\" />
+          <path fill=\\"none\\" d=\\"M152.333 24.298h127.432v109.036H152.333z\\" />
+          <switch>
+            <foreignObject
+              requiredExtensions=\\"http://ns.adobe.com/Flows/1.0/\\"
+              x=\\"0\\"
+              y=\\"0\\"
+              width=\\"1\\"
+              height=\\"1\\"
+              overflow=\\"visible\\"
+            >
+              <flowDef xmlns=\\"http://ns.adobe.com/Flows/1.0/\\">
+                <region textMatrix=\\"1 0 0 1 0 0\\">
+                  <path
+                    fill=\\"none\\"
+                    d=\\"M279.765 133.333h-130.49V24.298h130.49v109.035z\\"
+                  />
+                </region>
+                <flow xmlns=\\"http://ns.adobe.com/Flows/1.0/\\">
+                  <p text-align=\\"right\\" text-align-last=\\"right\\">
+                    <span fontFamily=\\"'TimesNewRomanPS-BoldMT'\\" fontSize=\\"9\\">
+                      ##3$$,
+                    </span>
+                    <span fontFamily=\\"'TimesNewRomanPSMT'\\" fontSize=\\"8.894\\" />
+                    <span fontFamily=\\"'TimesNewRomanPSMT'\\" fontSize=\\"7\\">
+                      ##2$$
+                    </span>
+                  </p>
+                  <p text-align=\\"right\\" text-align-last=\\"right\\">
+                    <span fontFamily=\\"'TimesNewRomanPSMT'\\" fontSize=\\"8\\">
+                      ##1$$,
+                    </span>
+                    <span fontFamily=\\"'TimesNewRomanPSMT'\\" fontSize=\\"8.596\\" />
+                    <span fontFamily=\\"'TimesNewRomanPSMT'\\" fontSize=\\"7\\">
+                      ##5$$
+                    </span>
+                  </p>
+                  <p text-align=\\"right\\" text-align-last=\\"right\\">
+                    <span fontFamily=\\"'TimesNewRomanPSMT'\\" fontSize=\\"8\\">
+                      ##10$$
+                    </span>
+                  </p>
+                  <p text-align=\\"right\\" text-align-last=\\"right\\">
+                    <span fontFamily=\\"'TimesNewRomanPSMT'\\" fontSize=\\"8\\">
+                      ##11$$
+                    </span>
+                  </p>
+                  <p text-align=\\"right\\" text-align-last=\\"right\\">
+                    <span fontFamily=\\"'TimesNewRomanPSMT'\\" fontSize=\\"8\\">
+                      ##7$$
+                    </span>
+                  </p>
+                  <p text-align=\\"right\\" text-align-last=\\"right\\">
+                    <span fontFamily=\\"'TimesNewRomanPSMT'\\" fontSize=\\"8\\">
+                      ##6$$
+                    </span>
+                  </p>
+                  <p text-align=\\"right\\" text-align-last=\\"right\\">
+                    <span fontFamily=\\"'TimesNewRomanPSMT'\\" fontSize=\\"8\\">
+                      ##8$$
+                    </span>
+                  </p>
+                  <p text-align=\\"right\\" text-align-last=\\"right\\">
+                    <span fontFamily=\\"'TimesNewRomanPSMT'\\" fontSize=\\"8\\">
+                      ##4$$
+                    </span>
+                  </p>
+                  <p text-align=\\"right\\" text-align-last=\\"right\\">
+                    <span fontFamily=\\"'TimesNewRomanPSMT'\\" fontSize=\\"8\\">
+                      ##17$$, ##18$$ ##19$$
+                    </span>
+                  </p>
+                </flow>
+              </flowDef>
+            </foreignObject>
+            <g>
+              <path fill=\\"none\\" d=\\"M149.275 24.298h130.49v109.036h-130.49z\\" />
+              <text transform=\\"translate(235.292 30.48)\\">
+                <tspan
+                  x=\\"0\\"
+                  y=\\"0\\"
+                  fontFamily=\\"'TimesNewRomanPS-BoldMT'\\"
+                  fontSize=\\"9\\"
+                >
+                  ##3$$,
+                </tspan>
+                <tspan
+                  x=\\"24.75\\"
+                  y=\\"0\\"
+                  fontFamily=\\"'TimesNewRomanPSMT'\\"
+                  fontSize=\\"8.894\\"
+                >
+                  {\\" \\"}
+                </tspan>
+                <tspan
+                  x=\\"26.974\\"
+                  y=\\"0\\"
+                  fontFamily=\\"'TimesNewRomanPSMT'\\"
+                  fontSize=\\"7\\"
+                >
+                  ##2$$
+                </tspan>
+                <tspan
+                  x=\\"2.825\\"
+                  y=\\"10.314\\"
+                  fontFamily=\\"'TimesNewRomanPSMT'\\"
+                  fontSize=\\"8\\"
+                >
+                  ##1$$,
+                </tspan>
+                <tspan
+                  x=\\"24.825\\"
+                  y=\\"10.314\\"
+                  fontFamily=\\"'TimesNewRomanPSMT'\\"
+                  fontSize=\\"8.596\\"
+                >
+                  {\\" \\"}
+                </tspan>
+                <tspan
+                  x=\\"26.974\\"
+                  y=\\"10.314\\"
+                  fontFamily=\\"'TimesNewRomanPSMT'\\"
+                  fontSize=\\"7\\"
+                >
+                  ##5$$
+                </tspan>
+                <tspan
+                  x=\\"20.474\\"
+                  y=\\"19.915\\"
+                  fontFamily=\\"'TimesNewRomanPSMT'\\"
+                  fontSize=\\"8\\"
+                >
+                  ##10$$
+                </tspan>
+                <tspan
+                  x=\\"20.474\\"
+                  y=\\"29.515\\"
+                  fontFamily=\\"'TimesNewRomanPSMT'\\"
+                  fontSize=\\"8\\"
+                >
+                  ##11$$
+                </tspan>
+                <tspan
+                  x=\\"24.474\\"
+                  y=\\"39.115\\"
+                  fontFamily=\\"'TimesNewRomanPSMT'\\"
+                  fontSize=\\"8\\"
+                >
+                  ##7$$
+                </tspan>
+                <tspan
+                  x=\\"24.474\\"
+                  y=\\"48.715\\"
+                  fontFamily=\\"'TimesNewRomanPSMT'\\"
+                  fontSize=\\"8\\"
+                >
+                  ##6$$
+                </tspan>
+                <tspan
+                  x=\\"24.474\\"
+                  y=\\"58.314\\"
+                  fontFamily=\\"'TimesNewRomanPSMT'\\"
+                  fontSize=\\"8\\"
+                >
+                  ##8$$
+                </tspan>
+                <tspan
+                  x=\\"24.474\\"
+                  y=\\"67.915\\"
+                  fontFamily=\\"'TimesNewRomanPSMT'\\"
+                  fontSize=\\"8\\"
+                >
+                  ##4$$
+                </tspan>
+                <tspan
+                  x=\\"-33.526\\"
+                  y=\\"77.515\\"
+                  fontFamily=\\"'TimesNewRomanPSMT'\\"
+                  fontSize=\\"8\\"
+                >
+                  ##17$$, ##18$$ ##19$$
+                </tspan>
+              </text>
+            </g>
+          </switch>
+          <path fill=\\"#251413\\" d=\\"M288.016 17.766h109.256v87.97H288.016z\\" />
+          <path
+            fill=\\"#4C2525\\"
+            d=\\"M46.389 234.756h13.958v13.958H46.389zM46.389 218.081h13.958v13.958H46.389z\\"
+          />
+          <g>
+            <path fill=\\"none\\" d=\\"M66.715 220.205h115.852v30.135H66.715z\\" />
+            <switch>
+              <foreignObject
+                requiredExtensions=\\"http://ns.adobe.com/Flows/1.0/\\"
+                x=\\"0\\"
+                y=\\"0\\"
+                width=\\"1\\"
+                height=\\"1\\"
+                overflow=\\"visible\\"
+              >
+                <flowDef xmlns=\\"http://ns.adobe.com/Flows/1.0/\\">
+                  <region textMatrix=\\"1 0 0 1 0 0\\">
+                    <path
+                      fill=\\"none\\"
+                      d=\\"M190.394 245.59H66.715v-25.385h123.679v25.385z\\"
+                    />
+                  </region>
+                  <flow
+                    xmlns=\\"http://ns.adobe.com/Flows/1.0/\\"
+                    fontFamily=\\"'TimesNewRomanPSMT'\\"
+                    fontSize=\\"5\\"
+                  >
+                    <p>
+                      <span>##25$$</span>
+                    </p>
+                  </flow>
+                </flowDef>
+              </foreignObject>
+              <g>
+                <path fill=\\"none\\" d=\\"M66.715 220.205h123.679v25.385H66.715z\\" />
+                <text
+                  transform=\\"translate(66.715 223.68)\\"
+                  fontFamily=\\"'TimesNewRomanPSMT'\\"
+                  fontSize=\\"5\\"
+                >
+                  ##25$$
+                </text>
+              </g>
+            </switch>
+          </g>
+        </svg>
+        {text}
+      </div>
+    );
+  }
+}
+Fakery.defaultProps = {
+  containerStyle: {},
+  svgStyle: {}
+};
+module.exports = Fakery;
+"
+`;
+
 exports[`toComponentModule options.template "fancy" with user-defined removeAttrs plugin 1`] = `
 "\\"use strict\\";
 const React = require(\\"react\\");
@@ -363,7 +645,7 @@ const React = require(\\"react\\");
 class SvgComponent extends React.PureComponent {
   render() {
     return (
-      <svg width=\\"414\\" height=\\"324\\" {...this.props}>
+      <svg width=\\"414\\" height=\\"324\\" viewBox=\\"0 0 414 324\\" {...this.props}>
         <path fill=\\"#FFF\\" d=\\"M.333.333h414v324h-414z\\" />
         <path fill=\\"none\\" d=\\"M152.333 24.298h127.432v109.036H152.333z\\" />
         <switch>
@@ -611,7 +893,12 @@ const React = require(\\"react\\");
 class StyleAttributes extends React.PureComponent {
   render() {
     return (
-      <svg width=\\"79.4\\" height=\\"69.855\\" {...this.props}>
+      <svg
+        width=\\"79.4\\"
+        height=\\"69.855\\"
+        viewBox=\\"0 0 79.4 69.855\\"
+        {...this.props}
+      >
         <defs>
           <clipPath id=\\"StyleAttributes-a\\" transform=\\"translate(-2.3 -8.8)\\">
             <rect

--- a/packages/svg-react-transformer/test/__snapshots__/to-jsx.test.js.snap
+++ b/packages/svg-react-transformer/test/__snapshots__/to-jsx.test.js.snap
@@ -15,7 +15,7 @@ exports[`toJsx passes SVGO plugins 1`] = `
 `;
 
 exports[`toJsx works on a big one 1`] = `
-"<svg width=\\"414\\" height=\\"324\\">
+"<svg width=\\"414\\" height=\\"324\\" viewBox=\\"0 0 414 324\\">
   <path fill=\\"#FFF\\" d=\\"M.333.333h414v324h-414z\\" />
   <path fill=\\"none\\" d=\\"M152.333 24.298h127.432v109.036H152.333z\\" />
   <switch>
@@ -242,7 +242,7 @@ exports[`toJsx works on a big one 1`] = `
 `;
 
 exports[`toJsx works on a layered one, preserving order 1`] = `
-"<svg data-name=\\"Layer 1\\" width=\\"200\\" height=\\"200\\">
+"<svg data-name=\\"Layer 1\\" width=\\"200\\" height=\\"200\\" viewBox=\\"0 0 200 200\\">
   <defs>
     <clipPath id=\\"layered-a\\">
       <path
@@ -384,7 +384,7 @@ exports[`toJsx works on an apple 1`] = `
 `;
 
 exports[`toJsx works on one with style attributes 1`] = `
-"<svg width=\\"79.4\\" height=\\"69.855\\">
+"<svg width=\\"79.4\\" height=\\"69.855\\" viewBox=\\"0 0 79.4 69.855\\">
   <defs>
     <clipPath id=\\"styleattributes-a\\" transform=\\"translate(-2.3 -8.8)\\">
       <rect

--- a/packages/svg-react-transformer/test/to-component-module.test.js
+++ b/packages/svg-react-transformer/test/to-component-module.test.js
@@ -177,6 +177,18 @@ describe('toComponentModule', () => {
     });
   });
 
+  test('options.template "fancy" with svg that could trigger removeViewBox', () => {
+    const options = {
+      name: 'Fakery',
+      template: 'fancy'
+    };
+    // svgo removeViewBox plugin will, by default since v1.0.0,
+    // remove `viewBox` attr which coincides with a width / height box
+    return toComponentModule(getFixture('big'), options).then(result => {
+      expect(format(result)).toMatchSnapshot();
+    });
+  });
+
   test('options.template "fancy" with user-defined removeAttrs plugin', () => {
     const options = {
       name: 'Fakery',


### PR DESCRIPTION
As part of #22, we upgraded the version of `svgo` from `^0.7.2` to `^1.3.0`. At v1.0.0, svgo [flipped the default for the `removeViewBox` plugin from "disabled" to "enabled"](https://github.com/svg/svgo/compare/v0.7.2...v1.0.0#diff-1f032887ecd460424aa526622f8d1b94R5).

We noticed that the snapshots changed, but didn't understand the significance: the `fancy` template requires there to be a viewBox.

This PR adds a failing regression test that will throw without the subsequent fix in this PR that restores svgo's pre-v1.0.0 behavior to disable the `removeViewBox` plugin.

Although this changes the output, it's a bug fix that only adds back additional properties that were getting omitted (and when the condition was getting triggered, causing a webpack build to fail). I think it should be a semver patch release. @davidtheclark 